### PR TITLE
Fix missing IAM permission to write to SSM param store

### DIFF
--- a/source/solution_deploy/lib/solution_deploy-stack.ts
+++ b/source/solution_deploy/lib/solution_deploy-stack.ts
@@ -459,7 +459,8 @@ export class SolutionDeployStack extends cdk.Stack {
             }),
             new PolicyStatement({
                 actions: [
-                    'ssm:GetParameter'
+                    'ssm:GetParameter',
+                    'ssm:PutParameter'
                 ],
                 resources: [`arn:${this.partition}:ssm:${this.region}:${this.account}:parameter/Solutions/SO0111/*`]
             }),


### PR DESCRIPTION
*Issue #, if available:* 47

*Description of changes:*
Fix missing IAM permission to write to SSM param store

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.